### PR TITLE
Fix saving newly created tasks

### DIFF
--- a/mikan-vuetify/src/pages/Kanban-3.vue
+++ b/mikan-vuetify/src/pages/Kanban-3.vue
@@ -230,6 +230,7 @@ function handleTaskSave(taskId, updatedTask) {
     boards.value[boardIndex].stages[stageIndex].tasks[taskIndex] = {
         ...existingTask,
         ...updatedTask,
+        id: taskId,
         dueDate: updatedTask.due_date,
         assignee: assigneeOptions.value.find(a => a.id === updatedTask.assignee_id)?.name || existingTask.assignee
     };


### PR DESCRIPTION
## Summary
- ensure defaults exist for new tasks when opening dialog
- update board task id after backend creates new task

## Testing
- `npm run type-check` *(fails: vue-tsc not found)*
- `npm run lint` *(fails: eslint-config-vuetify missing)*

------
https://chatgpt.com/codex/tasks/task_e_6887bb2ffa2c832688a55d0e5f510cbf