### PR TITLE
Fix Kanban refresh issue after saving tasks

### DIFF
--- a/mikan-vuetify/src/components/MyTasksComponent/TaskDetail.vue
+++ b/mikan-vuetify/src/components/MyTasksComponent/TaskDetail.vue
@@ -228,7 +228,7 @@
 import { ref, computed, watch, nextTick, onMounted } from 'vue'
 import axios from 'axios'
 import Attachment from '@/components/MyTasksComponent/AttachmentManager.vue'
-import { boards, fetchBoards } from '@/stores/boards'
+import { boards } from '@/stores/boards'
 
 const props = defineProps<{ modelValue: boolean; task: any; visitorMode?: boolean }>()
 const emit = defineEmits(['update:modelValue','save-task','delete-task'])
@@ -415,7 +415,7 @@ async function save() {
 
   localTask.value.attachments = [...existingAttachments, ...uploadedAttachments];
 
-  fetchBoards()
+
 
   // 🧼 Optional: console.log everything at end
   console.log("✔️ All updates done.");

--- a/mikan-vuetify/src/pages/Kanban-3.vue
+++ b/mikan-vuetify/src/pages/Kanban-3.vue
@@ -130,7 +130,7 @@
 <script setup lang="ts">
 import { ref,computed, watch } from 'vue'
 import axios from 'axios'
-import { boards } from '@/stores/boards'
+import { boards, fetchBoards } from '@/stores/boards'
 import { useRoute } from "vue-router";
 import draggable from 'vuedraggable'
 import Board from '@/components/MyTasksComponent/Board3-1.vue'
@@ -221,7 +221,7 @@ if (boardIndex!==null && stageIndex!==null && taskIndex!==null) {
 return null
 })
 
-function handleTaskSave(taskId, updatedTask) {
+async function handleTaskSave(taskId, updatedTask) {
   const { boardIndex, stageIndex, taskIndex } = editingInfo.value;
 
   if (boardIndex !== null && stageIndex !== null && taskIndex !== null) {
@@ -240,14 +240,14 @@ function handleTaskSave(taskId, updatedTask) {
       project_id: project_id,
     };
 
-    axios.put(`http://localhost:8000/tasks/update_task/${taskId}`, payload)
-      .then(() => {
-        console.log(`✅ Task updated from dialog with Task ID : ${taskId}`, payload);
-        isTaskDialogOpen.value = false;
-      })
-      .catch(err => {
-        console.error("❌ Failed to update task from dialog:", err);
-      });
+    try {
+      await axios.put(`http://localhost:8000/tasks/update_task/${taskId}`, payload);
+      console.log(`✅ Task updated from dialog with Task ID : ${taskId}`, payload);
+      await fetchBoards();
+      isTaskDialogOpen.value = false;
+    } catch (err) {
+      console.error("❌ Failed to update task from dialog:", err);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- avoid premature board refresh in TaskDetail
- refresh boards after task save completes in Kanban page

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-vuetify')*

------
https://chatgpt.com/codex/tasks/task_e_6887be0c48d48326b30083ad430f67cc