### PR TITLE
Fix kanban board task drop project id

### DIFF
--- a/mikan-vuetify/src/components/MyTasksComponent/Board3-1.vue
+++ b/mikan-vuetify/src/components/MyTasksComponent/Board3-1.vue
@@ -122,18 +122,19 @@
        :disabled="visitorMode"
      >
        <template #item="{ element: stage, index: sIndex }">
-         <Stage3
-          :stage="isFilterApplied
-                   ? { ...stage, tasks: filteredStages[sIndex].tasks }
-                   : stage"
-           :boardIndex="boardIndex"
-           :stageIndex="sIndex"
-           :visitorMode="visitorMode"
-           :selectedAssignee="selectedAssignee"
-          @rename-stage="(sIdx, title) => $emit('rename-stage', boardIndex, sIdx, title)"
-          @add-task="() => $emit('add-task', boardIndex, sIndex)"
-          @open-task-dialog="tIdx => $emit('open-task-dialog', boardIndex, sIndex, tIdx)"
-          @delete-stage="sIdx => $emit('delete-stage', boardIndex, sIdx)"
+          <Stage3
+            :stage="isFilterApplied
+                     ? { ...stage, tasks: filteredStages[sIndex].tasks }
+                     : stage"
+            :boardIndex="boardIndex"
+            :stageIndex="sIndex"
+            :visitorMode="visitorMode"
+            :projectId="board.id"
+            :selectedAssignee="selectedAssignee"
+            @rename-stage="(sIdx, title) => $emit('rename-stage', boardIndex, sIdx, title)"
+            @add-task="() => $emit('add-task', boardIndex, sIndex)"
+            @open-task-dialog="tIdx => $emit('open-task-dialog', boardIndex, sIndex, tIdx)"
+            @delete-stage="sIdx => $emit('delete-stage', boardIndex, sIdx)"
 		  @task-dropped="taskDropped"
          />
        </template>

--- a/mikan-vuetify/src/components/MyTasksComponent/Stage3-1.vue
+++ b/mikan-vuetify/src/components/MyTasksComponent/Stage3-1.vue
@@ -100,7 +100,8 @@ const props = defineProps({
   boardIndex: Number,
   stageIndex: Number,
   visitorMode: Boolean,
-  selectedAssignee: String
+  selectedAssignee: String,
+  projectId: Number
 })
 const emit = defineEmits(['add-task','delete-stage','open-task-dialog','rename-stage', 'task-dropped'])
 
@@ -127,13 +128,13 @@ function onTaskDrop(evt) {
     const newStatus = reverseStageMap[props.stage.title] || "to-do";
 
     // Only send update if status actually changed
-    if (task.status !== newStatus) {
-      const payload = {
-        assignee_id: task.assignee_id || 0,
-        project_id: props.boardIndex + 1,
-        title: task.title || "",
-        description: task.description || "",
-        due_date: task.dueDate || "",
+      if (task.status !== newStatus) {
+        const payload = {
+          assignee_id: task.assignee_id,
+          project_id: props.projectId,
+          title: task.title || "",
+          description: task.description || "",
+          due_date: task.dueDate || "",
         priority: task.priority || "",
         status: newStatus
       };


### PR DESCRIPTION
## Summary
- fix kanban board drag-n-drop payload to use real project id
- pass project id from board to stage for updates

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-vuetify')*

------
https://chatgpt.com/codex/tasks/task_e_6887b7b08cac8326981afacdebae2156